### PR TITLE
1.0 Supported long running task

### DIFF
--- a/CloudOSTunnel/Clients/VMWareClient.cs
+++ b/CloudOSTunnel/Clients/VMWareClient.cs
@@ -27,9 +27,11 @@ namespace CloudOSTunnel.Clients
 
         #region vCenter Attributes
         // Maximum time for VM guest to stop services and start rebooting
-        private const int GUEST_TIME_TO_SHUTDOWN_SECONDS = 60;
+        // - Note that after installed updates, it can take long to shutdown
+        private const int GUEST_TIME_TO_SHUTDOWN_SECONDS = 1800;
         // Maximum time for VM guest to run a program
-        private const int GUEST_OPERATIONS_TASK_TIMEOUT_SECONDS = 120;
+        // - Note that it can take long to install updates
+        private const int GUEST_OPERATIONS_TASK_TIMEOUT_SECONDS = 3600;
         // Maximum time to wait for guest operations to be ready, note the below:
         // - VMware Tools takes time to load completely and guest operations may experience transient states e.g. up,down,up..
         // - After Windows patching, it can take long time to boot into operating system, hence a high timeout value
@@ -112,7 +114,7 @@ namespace CloudOSTunnel.Clients
         public string GuestFullName { get; }
         #endregion vCenter Attributes
 
-        #region Linux Guest Variables
+        #region Linux Guest Attributes
         public string EntryMessage { get; set; }
         private string _baseOutputPath = "/tmp/vmwaretunnel-";
         public int SSHMessageCount = 0;
@@ -121,7 +123,7 @@ namespace CloudOSTunnel.Clients
         public string PrivateFileLocation;
         public string PublicKey;
         public string SessionId { get; }
-        #endregion Linux Guest Variables
+        #endregion Linux Guest Attributes
 
         #region Windows Guest Attributes
         // Root path in Windows guest (to store temporal files)

--- a/CloudOSTunnel/Services/WSMan/WSManRuntime.cs
+++ b/CloudOSTunnel/Services/WSMan/WSManRuntime.cs
@@ -448,7 +448,7 @@ namespace CloudOSTunnel.Services.WSMan
             string requestMessageId = xml.GetElementsByTagName("a:MessageID").Item(0).InnerText;
             string signalCode = xml.GetElementsByTagName("rsp:Code").Item(0).InnerText;
 
-            LogInformation("Received signal terminate");
+            LogInformation(string.Format("Received signal code {0}", signalCode));
 
             string responseMessageId = "uuid:" + Guid.NewGuid();
 

--- a/CloudOSTunnel/Services/WSMan/WSManServer.cs
+++ b/CloudOSTunnel/Services/WSMan/WSManServer.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Text;
 using System.Xml;
 using System.Net;
+using System.Security.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -111,6 +112,11 @@ namespace CloudOSTunnel.Services.WSMan
                         {
                             LogInformation(string.Format("Configuring https web host on port {0}", port));
                             listenOptions.UseHttps(certPath, certPassword);
+                            /*
+                            listenOptions.UseHttps(certPath, certPassword,
+                                httpsOptions => {
+                                    httpsOptions.SslProtocols = SslProtocols.Tls12 | SslProtocols.Ssl3;
+                                });*/
                         }
                         else
                         {

--- a/CloudOSTunnel/Services/WSMan/WSManServer.cs
+++ b/CloudOSTunnel/Services/WSMan/WSManServer.cs
@@ -112,11 +112,14 @@ namespace CloudOSTunnel.Services.WSMan
                         {
                             LogInformation(string.Format("Configuring https web host on port {0}", port));
                             listenOptions.UseHttps(certPath, certPassword);
+                            
                             /*
                             listenOptions.UseHttps(certPath, certPassword,
                                 httpsOptions => {
-                                    httpsOptions.SslProtocols = SslProtocols.Tls12 | SslProtocols.Ssl3;
-                                });*/
+                                    //httpsOptions.SslProtocols = SslProtocols.Tls12 | SslProtocols.Ssl3;
+                                    httpsOptions.SslProtocols = SslProtocols.Ssl3;
+                                }
+                            ); */
                         }
                         else
                         {

--- a/CloudOSTunnel/Services/WSMan/WSManStartup.cs
+++ b/CloudOSTunnel/Services/WSMan/WSManStartup.cs
@@ -43,9 +43,10 @@ namespace CloudOSTunnel.Services.WSMan
             app.UseHttpsRedirection();
             app.UseMvc();
             app.Run(wsmanHandler.HandleRequest);
-            /* app.Run(async context =>
+            /*
+            app.Run(async context =>
             {
-                await context.Response.WriteAsync("Hello, World!");
+                await wsmanHandler.HandleRequest(context);
             });*/
         }
     }


### PR DESCRIPTION
Supported long running task because Windows can take very long to install updates and reboot.

Note: win_reboot is NOT supported as it is not reliable. Instead, use win_shell with "Restart-Computer -Force"