### PR TITLE
1.0 Supported docker and allow getting guest os version

### DIFF
--- a/CloudOSTunnel/Clients/VMWareClient.cs
+++ b/CloudOSTunnel/Clients/VMWareClient.cs
@@ -31,7 +31,7 @@ namespace CloudOSTunnel.Clients
         private const int GUEST_TIME_TO_SHUTDOWN_SECONDS = 1800;
         // Maximum time for VM guest to run a program
         // - Note that it can take long to install updates
-        private const int GUEST_OPERATIONS_TASK_TIMEOUT_SECONDS = 3600;
+        private const int GUEST_OPERATIONS_TASK_TIMEOUT_SECONDS = 7200;
         // Maximum time to wait for guest operations to be ready, note the below:
         // - VMware Tools takes time to load completely and guest operations may experience transient states e.g. up,down,up..
         // - After Windows patching, it can take long time to boot into operating system, hence a high timeout value

--- a/CloudOSTunnel/Clients/VMWareClient.cs
+++ b/CloudOSTunnel/Clients/VMWareClient.cs
@@ -129,6 +129,12 @@ namespace CloudOSTunnel.Clients
         // Root path in Windows guest (to store temporal files)
         private const string windowsGuestRoot = @"C:\Users\Public\Documents";
 
+        // Get Windows guest full path for a file name
+        private string GetWindowsGuestPath(string filename)
+        {
+            return string.Format(@"{0}\{1}", windowsGuestRoot, filename);
+        }
+
         internal string VmUser
         {
             get { return _executingCredentials.Username; }
@@ -842,8 +848,9 @@ namespace CloudOSTunnel.Clients
         public CommandResult ExecuteWindowsCommand(string command)
         {
             string vmPrefix = GetWsmanFilePrefix();
-            string stdoutPathGuest = Path.Join(windowsGuestRoot, vmPrefix + "_stdout.txt");
-            string stderrPathGuest = Path.Join(windowsGuestRoot, vmPrefix + "_stderr.txt");
+            
+            string stdoutPathGuest = GetWindowsGuestPath(vmPrefix + "_stdout.txt");
+            string stderrPathGuest = GetWindowsGuestPath(vmPrefix + "_stderr.txt");
 
             string fullCommand = WrapWindowsCommand(command, stdoutPathGuest, stderrPathGuest);
 
@@ -891,10 +898,10 @@ namespace CloudOSTunnel.Clients
 
             string filePrefix = GetWsmanFilePrefix(commandId);
 
-            string stdoutPathGuest = Path.Join(windowsGuestRoot, filePrefix + "_stdout.txt");
-            string stderrPathGuest = Path.Join(windowsGuestRoot, filePrefix + "_stderr.txt");
-            string payloadPathGuest = Path.Join(windowsGuestRoot, filePrefix + "_payload.txt");
-            string cmdPathGuest = Path.Join(windowsGuestRoot, filePrefix + "_command.ps1");
+            string stdoutPathGuest = GetWindowsGuestPath(filePrefix + "_stdout.txt");
+            string stderrPathGuest = GetWindowsGuestPath(filePrefix + "_stderr.txt");
+            string payloadPathGuest = GetWindowsGuestPath(filePrefix + "_payload.txt");
+            string cmdPathGuest = GetWindowsGuestPath(filePrefix + "_command.ps1");
 
             string cmdPathServer = Path.Join(Path.GetTempPath(), port + "_command.ps1");
 

--- a/CloudOSTunnel/Clients/VMWareClient.cs
+++ b/CloudOSTunnel/Clients/VMWareClient.cs
@@ -339,7 +339,7 @@ namespace CloudOSTunnel.Clients
             do
             {
                 // Reduce number of calls to vCenter
-                Thread.Sleep(500);
+                Thread.Sleep(1000);
 
                 if (stopWatch.Elapsed.TotalSeconds > timeoutSeconds)
                 {

--- a/CloudOSTunnel/Clients/VMWareClient.cs
+++ b/CloudOSTunnel/Clients/VMWareClient.cs
@@ -179,6 +179,48 @@ namespace CloudOSTunnel.Clients
         }
         #endregion Logging
 
+        #region Guest Info
+        public string GetGuestOs()
+        {
+            if (GuestFamily.Contains("Windows"))
+            {
+                return GuestFullName;
+            }
+
+            string cmd;
+
+            if(GuestFullName.Contains("CentOS"))
+            {
+                // CentOS Linux release 7.6.1810 (Core)
+                cmd = "cat /etc/centos-release";
+            }
+            else if(GuestFullName.Contains("Red Hat Enterprise Linux"))
+            {
+                // Red Hat Enterprise Linux Server release 7.4 (Maipo)
+                cmd = "cat /etc/redhat-release";
+            }
+            else if(GuestFullName.Contains("SUSE"))
+            {
+                // SUSE Linux Enterprise Server 11 (x86_64)
+                // VERSION = 11
+                // PATCHLEVEL = 4
+                cmd = "cat /etc/SuSE-release";
+            }
+            else if(GuestFullName.Contains("Ubuntu"))
+            {
+                // Description:    Ubuntu 18.04.3 LTS
+                cmd = "lsb_release -d";
+            }
+            else
+            {
+                throw new CloudOSTunnelException(string.Format("Unsupported guest OS {0}", GuestFullName));
+            }
+
+            return ExecuteLinuxCommand(cmd, out _, out _);
+        }
+
+        #endregion Guest Info
+        
         // Create a client using VM name
         public VMWareClient(ILoggerFactory loggerFactory, string serviceUrl, string vcenterUsername, string vcenterPassword, 
             string vmUsername, string vmPassword, string vmName, string moref)

--- a/CloudOSTunnel/CloudOSTunnel.csproj
+++ b/CloudOSTunnel/CloudOSTunnel.csproj
@@ -3,12 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <UserSecretsId>f2137130-5ead-4fba-8652-5a4acdbf23d6</UserSecretsId>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.1.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.12" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc2" />
   </ItemGroup>
 

--- a/CloudOSTunnel/CloudOSTunnel.csproj
+++ b/CloudOSTunnel/CloudOSTunnel.csproj
@@ -33,7 +33,6 @@
 
   <ItemGroup>
     <Folder Include="Certificates\" />
-    <Folder Include="ViewModels\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CloudOSTunnel/Controllers/VMWareController.cs
+++ b/CloudOSTunnel/Controllers/VMWareController.cs
@@ -32,5 +32,18 @@ namespace CloudOSTunnel.Controllers
                 Exists = result
             });
         }
+
+        [HttpPost]
+        [Route("guest-os")]
+        public IActionResult GetGuestOs([FromBody] GetVMWareGuestOs request)
+        {
+            var client = new VMWareClient(_logger, request.ServiceUrl, request.VCenterUsername, request.VCenterPassword, request.OSUsername, request.OSPassword, request.MoRef);
+            var result = client.GetGuestOs();
+            client.Logout();
+            return Ok(new
+            {
+                GuestOs = result
+            });
+        }
     }
 }

--- a/CloudOSTunnel/Properties/launchSettings.json
+++ b/CloudOSTunnel/Properties/launchSettings.json
@@ -24,6 +24,18 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:5001"
+    },
+    "Docker": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/api/values",
+      "environmentVariables": {
+        "ASPNETCORE_URLS": "https://+:443;http://+:80",
+        "ASPNETCORE_HTTPS_PORT": "44333"
+      },
+      "httpPort": 52996,
+      "useSSL": true,
+      "sslPort": 44333
     }
   }
 }

--- a/CloudOSTunnel/ViewModels/GetVMWareGuestOs.cs
+++ b/CloudOSTunnel/ViewModels/GetVMWareGuestOs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CloudOSTunnel.ViewModels
+{
+    public class GetVMWareGuestOs
+    {
+        [Required]
+        public string ServiceUrl { get; set; }
+        [Required]
+        public string VCenterUsername { get; set; }
+        [Required]
+        public string VCenterPassword { get; set; }
+        [Required]
+        public string MoRef { get; set; }
+        [Required]
+        public string OSUsername { get; set; }
+        [Required]
+        public string OSPassword { get; set; }
+    }
+}

--- a/CloudOSTunnel/appsettings.json
+++ b/CloudOSTunnel/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information"
     }
   },
   "AllowedHosts": "*",

--- a/Docker_Build_Push_Auto.bat
+++ b/Docker_Build_Push_Auto.bat
@@ -1,0 +1,10 @@
+@echo off
+
+set /p v="What version is this? "
+
+set /p type="dev, uat or prod? "
+
+docker build -f ./Dockerfile -t public-cloud-portal:edpc_cloudostunnel_%type%_v%v% .
+docker tag public-cloud-portal:edpc_cloudostunnel_%type%_v%v% eddevops1/public-cloud-portal:edpc_cloudostunnel_%type%_v%v%
+docker push eddevops1/public-cloud-portal:edpc_cloudostunnel_%type%_v%v%
+Pause

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 5002-5004
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-stretch AS build
+WORKDIR /src
+COPY ["CloudOSTunnel/CloudOSTunnel.csproj", "CloudOSTunnel/"]
+COPY ["FxSsh/FxSsh/FxSsh.csproj", "FxSsh/FxSsh/"]
+RUN dotnet restore "CloudOSTunnel/CloudOSTunnel.csproj"
+COPY . .
+WORKDIR "/src/CloudOSTunnel"
+RUN dotnet build "CloudOSTunnel.csproj" -c Release -o /app
+
+FROM build AS publish
+RUN dotnet publish "CloudOSTunnel.csproj" -c Release -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+COPY --from=build /src/CloudOSTunnel/Certificates/*.pfx ./Certificates/
+ENTRYPOINT ["dotnet", "CloudOSTunnel.dll"]


### PR DESCRIPTION
Note that AWX should be creating Windows hosts with these variables examples:
ansible_port: 5002
ansible_connection: winrm
ansible_winrm_scheme: https (or http if not using SSL)
ansible_winrm_server_cert_validation: ignore
ansible_winrm_read_timeout_sec: 9000 (must be higher than operation timeout)
ansible_winrm_operation_timeout_sec: 7200 (match tunnel task timeout)